### PR TITLE
Deoxys now stores data from Genesis block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ git # Madara Changelog
 
 ## Next release
 
+- fix(genesis): #107
 - fix(class): #32 #33 #34
 - fix(class): #116
 - feat(class): download classes from sequencer

--- a/crates/client/deoxys/src/lib.rs
+++ b/crates/client/deoxys/src/lib.rs
@@ -14,7 +14,7 @@ pub mod m;
 type CommandSink = futures::channel::mpsc::Sender<sc_consensus_manual_seal::rpc::EngineCommand<sp_core::H256>>;
 
 pub async fn sync(sender_config: SenderConfig, fetch_config: FetchConfig, rpc_port: u16, l1_url: Url) {
-    let first_block = utility::get_last_synced_block(rpc_port).await + 1;
+    let first_block = utility::get_last_synced_block(rpc_port).await;
 
     let _ = join!(l1::sync(l1_url, rpc_port), l2::sync(sender_config, fetch_config, first_block, rpc_port));
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Genesis block data, such as transactions and contract address to clash hash equivalence, are not being stored.

Resolves #107 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Blockchain data is now stored as off Genesis block.

## Does this introduce a breaking change?

Yes. Nodes with a working local database will need to re-synchronize from block 0 for this change to take effect.
